### PR TITLE
Fix install script (demo still broken)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,8 @@ function get_crypto {
     echo "Get Milagro Crypto Libraries"
     mkdir -p install
     cd install || exit
-    git clone https://github.com/miracl/milagro-crypto.git
+    git clone https://github.com/miracl/milagro-crypto-c.git milagro-crypto \
+        || echo "Crypto library clone failed, assuming it already exists"
 
     cd milagro-crypto || exit
 }

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 BASE_DIR=$(pwd)
 
@@ -32,18 +33,18 @@ function install_dependencies {
 function get_crypto {
     echo "Get Milagro Crypto Libraries"
     mkdir -p install
-    cd install || exit
+    cd install
     git clone https://github.com/miracl/milagro-crypto-c.git milagro-crypto \
         || echo "Crypto library clone failed, assuming it already exists"
 
-    cd milagro-crypto || exit
+    cd milagro-crypto
 }
 
 function build_crypto {
     echo "Build Milagro crypto library"
 
-    mkdir Release
-    cd Release || exit
+    mkdir -p Release
+    cd Release
     cmake ..
     make
     make test
@@ -51,7 +52,7 @@ function build_crypto {
 }
 
 function get_credentials {
-    cd "$BASE_DIR" || exit
+    cd "$BASE_DIR"
     python scripts/getCommunityCredentials.py .
 }
 
@@ -59,12 +60,12 @@ function build_frontend {
     echo "build frontend js"
 
     # Go to frontend code location
-    cd "$FRONTEND_LOCATION" || exit
+    cd "$FRONTEND_LOCATION"
     # run frontend build script
     ./build.sh
 
     # Create the needed directory and link the frontend
-    cd "$BASE_DIR/servers/demo/public/" || exit
+    cd "$BASE_DIR/servers/demo/public/"
 
     ln -sf "$FRONTEND_LOCATION/build/out/browser" mpin
 }
@@ -85,7 +86,7 @@ function get_dependencies {
 function configure_dta {
     echo "Configure DTA"
 
-    cd "$BASE_DIR/servers/dta" || exit
+    cd "$BASE_DIR/servers/dta"
 
     CONFIGURE=1
     if [ -f config.py ]
@@ -120,7 +121,7 @@ function configure_dta {
 function configure_rps {
     echo "Configure RPS"
 
-    cd "$BASE_DIR/servers/rps" || exit
+    cd "$BASE_DIR/servers/rps"
 
     CONFIGURE=1
     if [ -f config.py ]
@@ -148,7 +149,7 @@ function configure_rps {
 function configure_demo {
     echo "Configure Demo RPA"
 
-    cd "$BASE_DIR/servers/demo" || exit
+    cd "$BASE_DIR/servers/demo"
 
     CONFIGURE=1
     if [ -f config.py ]


### PR DESCRIPTION
Fixes to stop letting errors fall through in the install bash script & correct the (renamed?) repo URL for the C crypto library.

This gets me to a point where the install scripts succeeds.

However, running the DTA server as per instructions fails as following:
```
ubuntu@ip-172-18-80-77:~/milagro-mfa-server$ python servers/dta/dta.py
Traceback (most recent call last):
  File "servers/dta/dta.py", line 48, in <module>
    from mpin_utils import secrets
  File "/home/ubuntu/milagro-mfa-server/lib/mpin_utils/secrets.py", line 32, in <module>
    import crypto
  File "/home/ubuntu/milagro-mfa-server/lib/crypto.py", line 19, in <module>
    import mpin
ImportError: No module named mpin
```

Indeed, there's no `mpin.py` anywhere on the machine, only the following similar files:
```
ubuntu@ip-172-18-80-77:/$ find . -name 'mpin*.py' 2> /dev/null
./home/ubuntu/milagro-mfa-server/servers/demo/mpinDemo.py
./home/ubuntu/milagro-mfa-server/install/milagro-crypto/wrappers/python/mpin_ZZZ.py
./home/ubuntu/milagro-mfa-server/install/milagro-crypto/Release/wrappers/python/mpin_BN254CX.py
```

I'm not amazingly familiar with CMake, any help appreciated.

Running on AWS Ubuntu AMI, `uname -a`: `Linux ip-172-18-80-77 4.4.0-1022-aws #31-Ubuntu SMP Tue Jun 27 11:27:55 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux`

Other diagnostic info:
```
ubuntu@ip-172-18-80-77:/usr/local/lib$ ls
libamcl_core.so  libamcl_curve_BN254CX.so  libamcl_mpin_BN254CX.so  libamcl_pairing_BN254CX.so  libamcl_rsa_2048.so  libamcl_wcc_BN254CX.so  python2.7  python3.5
ubuntu@ip-172-18-80-77:/usr/local/lib$ ls python2.7/
dist-packages/ site-packages/
ubuntu@ip-172-18-80-77:/usr/local/lib$ ls python2.7/site-packages/
ubuntu@ip-172-18-80-77:/usr/local/lib$ ls python2.7/dist-packages/
backports                                      certifi-2017.7.27.1.dist-info  _cffi_backend.so     pbkdf2.py   pycparser-2.18.egg-info          redis-2.10.3.egg-info  six.pyc
backports.ssl_match_hostname-3.5.0.1.egg-info  cffi                           dateutil             pbkdf2.pyc  python_dateutil-2.4.2.dist-info  six-1.11.0.dist-info   tornado
certifi                                        cffi-0.8.6.egg-info            pbkdf2-1.3.egg-info  pycparser   redis                            six.py                 tornado-4.1.egg-info
ubuntu@ip-172-18-80-77:/$ echo $LD_LIBRARY_PATH
:/usr/local/lib:/usr/local/lib:/usr/local/lib:/usr/local/lib
ubuntu@ip-172-18-80-77:/$ echo $PYTHONPATH
/home/ubuntu/milagro-mfa-server/lib:/usr/local/lib/python2.7/dist-packages
# Note: changing dist-packages to site-packages doesn't work either
```

